### PR TITLE
Making type extraction work for the dynamic component settings

### DIFF
--- a/.storybook/stories/automatedStories.js
+++ b/.storybook/stories/automatedStories.js
@@ -28,8 +28,15 @@ function getControlForProp(prop, controlOptions) {
     control = { control: { type: prop.type.toLowerCase() } };
   } else if (/^(?:string)$/i.test(prop.type)) {
     if (!/^(?:string|number|boolean|object)$/i.test(prop.complexType.original)) {
-      const arrOptions = prop.complexType.original.split(' | ');
-      const selectOptions = arrOptions.map(o => (o.match(/('(\w|-)+')/g) ? o.replace(/'|\|/gi, '').trim() : o));
+      const arrOptions = prop.complexType.resolved.split(' | ');
+      const selectOptions = arrOptions.map(o => (
+        o.match(/("(\w|-)+")|('(\w|-)+')/g) ? o
+          .replace(/'|\|/gi, '')
+          .replace(/"|\|/gi, '')
+          .replace(/'/gi, '')
+          .replace(/`/gi, '')
+          .trim() : o
+      ));
 
       control = {
         control: {

--- a/src/components/globals.ts
+++ b/src/components/globals.ts
@@ -1,3 +1,2 @@
 export type Color = 'primary' | 'secondary';
 export type Shape = 'full' | 'round' | 'smooth';
-export type Size = 'large' | 'medium' | 'small';

--- a/src/components/globals.ts
+++ b/src/components/globals.ts
@@ -1,0 +1,3 @@
+export type Color = 'primary' | 'secondary';
+export type Shape = 'full' | 'round' | 'smooth';
+export type Size = 'large' | 'medium' | 'small';

--- a/src/components/my-button/my-button.tsx
+++ b/src/components/my-button/my-button.tsx
@@ -1,5 +1,6 @@
 import { Component, Host, h, Prop } from '@stencil/core';
 import clsx from 'clsx';
+import { Color, Shape, Size } from '../globals';
 
 @Component({
   tag: 'my-button',
@@ -7,11 +8,11 @@ import clsx from 'clsx';
   shadow: true,
 })
 export class MyButton {
-  @Prop() color?: 'primary' | 'secondary' = 'primary';
+  @Prop() color?: Color = 'primary';
   @Prop({ reflect: true }) disabled?: boolean = false;
   @Prop({ reflect: true }) elevation?: boolean = false;
-  @Prop() shape?: 'full' | 'round' | 'smooth' = 'smooth';
-  @Prop() size?: 'large' | 'medium' | 'small' = 'medium';
+  @Prop() shape?: Shape = 'smooth';
+  @Prop() size?: Size = 'medium';
 
   render() {
     return (

--- a/src/components/my-button/my-button.tsx
+++ b/src/components/my-button/my-button.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, h, Prop } from '@stencil/core';
 import clsx from 'clsx';
-import { Color, Shape, Size } from '../globals';
+import { Color, Shape } from '../globals';
 
 @Component({
   tag: 'my-button',

--- a/src/components/my-button/my-button.tsx
+++ b/src/components/my-button/my-button.tsx
@@ -12,7 +12,7 @@ export class MyButton {
   @Prop({ reflect: true }) disabled?: boolean = false;
   @Prop({ reflect: true }) elevation?: boolean = false;
   @Prop() shape?: Shape = 'smooth';
-  @Prop() size?: Size = 'medium';
+  @Prop() size?: 'large' | 'medium' | 'small' = 'medium';
 
   render() {
     return (


### PR DESCRIPTION
To my relief I stumbled upon your repository and started to use it, but I found that it couldn't handle types that were extracted as a global type and were referenced in the components.
This PR is to fix that issue. I left one of the types defined in place to show that the original way is still working as well.
Thanks for the whole thing,
Cheers!